### PR TITLE
Added the AppFolder parameter

### DIFF
--- a/App.json
+++ b/App.json
@@ -36,8 +36,6 @@
         }
     ],
     "TenantInformation": {
-        "Name": "tenant.onmicrosoft.com",
-        "PromptBehavior": "Always \\ Auto \\ Never",
-        "ApplicationID": "d1ddf0e4-d672-4dae-b554-9d5bdfd93547"
+        "ID": "f8a9903e-111f-4bab-9980-4ab7dc637d43"
     }
 }

--- a/Create-Win32App.ps1
+++ b/Create-Win32App.ps1
@@ -23,11 +23,12 @@
     Author:      Nickolaj Andersen
     Contact:     @NickolajA
     Created:     2020-09-26
-    Updated:     2020-10-06
+    Updated:     2021-11-02
 
     Version history:
     1.0.0 - (2020-09-26) Script created
     1.0.1 - (2020-10-06) Added the AppFolder parameter. Allows for a single copy of the script in the root of the app directory rather than a separate copy in each app folder.
+    1.0.2 - (2021-11-02) Updated the Connect-MSIntuneGraph parameters
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
@@ -91,7 +92,7 @@ Process {
 
     if (-not($PSBoundParameters["Validate"])) {
         # Connect and retrieve authentication token
-        Connect-MSIntuneGraph -TenantName $AppData.TenantInformation.Name -PromptBehavior $AppData.TenantInformation.PromptBehavior -ApplicationID $AppData.TenantInformation.ApplicationID -Verbose
+        Connect-MSIntuneGraph -TenantId $AppData.TenantInformation.ID -Verbose
     }
 
     # Create required .intunewin package from source folder


### PR DESCRIPTION
Added an optional parameter named AppFolder. This allows for one copy of the script to be located at the root of the applications directory instead of needing a separate copy in each application folder. Also added logic to verify required files and folder structure exist.